### PR TITLE
fix: the function onAddToCart on'card.component and details.component'

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -103,5 +103,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/features/products/card/card.component.ts
+++ b/src/app/features/products/card/card.component.ts
@@ -51,6 +51,7 @@ export class CardComponent {
   @Output() addToCartEvent = new EventEmitter<Product>();
 
   onAddToCart(): void {
-    this.addToCartEvent.emit(this.product());
+    const productWithQty = { ...this.product(), qty: 1 };
+    this.addToCartEvent.emit(productWithQty)
   }
 }

--- a/src/app/features/products/details/details.component.ts
+++ b/src/app/features/products/details/details.component.ts
@@ -26,8 +26,9 @@ export default class DetailsComponent implements OnInit {
     this.product = this.productsSvc.getProductById(this.productId());
   }
 
-  onAddToCart() {
-    this.cartStore.addToCart(this.product() as Product);
+  onAddToCart(): void {
+    const productWithQty = { ...this.product(), qty: 1 };
+    this.cartStore.addToCart(productWithQty as Product)
   }
 
   generateSVG(index: number): SafeHtml {


### PR DESCRIPTION
# Change Summary

## Summary of Changes

I addressed two main issues in the project:

1. **Cart Quantity Issue**: When a product was added to the cart, navigated to the checkout page, and the order was deleted, adding the product again would add the previous quantity instead of just one unit.

2. **Quantity Recognition in Item Details**: Within the item details page, the system recognized the quantity as NaN because the quantity (qty) was not being set.

## Motivation and Context

These fixes were necessary to ensure the correct functionality of the shopping cart and to prevent calculation errors on the item details page.

## How the Changes Were Tested

The changes were tested locally to ensure that the cart's product quantity would be correctly reset to 1 after an order was deleted and that the item details page would no longer display the NaN error when adding an item.

## Proposed Changes

- **Shopping Cart**: Modified the logic for adding products to the cart to ensure that the quantity is reset to 1 after an order is deleted.
- **Item Details Page**: Added the definition of the quantity (qty) to prevent the NaN error when adding an item.

## Impact of the Changes

- **Shopping Cart Functionality**: Improved user experience by ensuring that the product quantity in the cart is correctly reset to 1 after an order is deleted.
- **Item Details Page**: Fixed the error that prevented items from being added to the item details page.
